### PR TITLE
fix: The environment does not contain `Std.TreeSet.diff` & `Std.TreeSet.subset` & `Std.TreeSet.union` & Unknown identifier `HashMap`

### DIFF
--- a/Canonical/FromCanonical.lean
+++ b/Canonical/FromCanonical.lean
@@ -1,5 +1,6 @@
 import Canonical.Basic
 import Canonical.ToCanonical
+import Std.Data.HashMap
 import Lean
 
 namespace Canonical
@@ -8,7 +9,7 @@ open Lean hiding Term
 open Std Meta Syntax
 
 /-- When translating from Canonical, we associate names in the `Term` with corresponding Lean `FVarId`s -/
-abbrev FromCanonicalM := StateT (HashMap String FVarId) MetaM
+abbrev FromCanonicalM := StateT (Std.HashMap String FVarId) MetaM
 
 /-- Converts instances of `Pi.mk` and `Pi.f` at the head into λ-expressions and applications, respectively. -/
 partial def removePi (t : Term) : Term :=

--- a/Canonical/Monomorphize.lean
+++ b/Canonical/Monomorphize.lean
@@ -4,6 +4,12 @@ open Meta
 
 namespace Monomorphize
 
+@[inline]
+def Std.TreeSet.subset (t₁ t₂ : TreeSet α cmp) : Bool :=
+  t₁.all (t₂.contains ·)
+
+abbrev NameSet.subset : NameSet -> NameSet -> Bool := Std.TreeSet.subset
+
 /-- An expression with `levels` as `param` universes. -/
 structure UnivAbstracted where
   expr: Expr
@@ -53,8 +59,8 @@ def addConstant (name : Name) : MonoM Unit := do
 /-- Add `names` to `constNames`. -/
 def addConstants (names : NameSet) : MonoM Unit := do
   modify fun s => { s with
-    constNames := s.constNames.union names,
-    hasNewConst := s.hasNewConst || !names.subset s.constNames
+    constNames := Union.union s.constNames names,
+    hasNewConst := s.hasNewConst || !(NameSet.subset names s.constNames)
   }
 
 def getConstants : MonoM NameSet := do

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.22.0
+leanprover/lean4:v4.23.0-rc2


### PR DESCRIPTION
fixes #23 

waiting for https://github.com/leanprover/lean4/pull/10226