### PR TITLE
added librarySearch option

### DIFF
--- a/Canonical/Main.lean
+++ b/Canonical/Main.lean
@@ -6,7 +6,7 @@ import Canonical.Preprocess
 
 namespace Canonical
 
-open Lean Parser Tactic Meta Elab Tactic Core PremiseSelection
+open Lean Parser Tactic Meta Elab Tactic Core LibrarySearch PremiseSelection
 
 /-- The return type of Canonical, with the generated `terms`. -/
 structure CanonicalResult where

--- a/Canonical/Main.lean
+++ b/Canonical/Main.lean
@@ -49,6 +49,11 @@ elab (name := canonicalSeq) "canonical " timeout_syntax:(num)? config:optConfig 
 
   let config ← canonicalConfig config
 
+  if config.librarySearch then
+    let (_, goal) ← (← getMainGoal).intros
+    goal.withContext do
+    premises := premises ++ (← librarySearchSymm libSearchFindDecls (← getMainGoal)).map (·.2.1)
+
   if config.premises then
     let found ← select (← getMainGoal)
     let found := found.insertionSort (fun a b => a.score > b.score)

--- a/Canonical/TranslationUtil.lean
+++ b/Canonical/TranslationUtil.lean
@@ -25,6 +25,8 @@ structure CanonicalConfig where
   monomorphize: Bool := true
   /-- Unpacks structure types in a preprocessing stage.  -/
   destruct: Bool := true
+  /-- Add librarySearch lemmas used by `exact?` and `apply?` -/
+  librarySearch: Bool := true
   /-- Add premises from the current premise selector. -/
   premises: Bool := false
 


### PR DESCRIPTION
The core search process from `exact?` and `apply?` is applied to the initial goal expr to retrieve relevant lemmas. This lemmas will often be missed by the llm premise selector.

By default the `librarySearch` option is enabled in the config.