### PR TITLE
Monomorphize Tactic: kernel-valid symbols and universe fixes

### DIFF
--- a/Canonical/Monomorphize/Basic.lean
+++ b/Canonical/Monomorphize/Basic.lean
@@ -117,10 +117,19 @@ def onlyHasGlobalFVars (e : Expr) : MonoM Bool := do
   let p := fun x => !globalFVars.contains x
   return !e.hasAnyFVar p
 
+/-- `abstractMVars`, after instantiating the types of the metavariables of `e`. Otherwise an
+already assigned universe metavariable that occurs only in the type of an abstracted
+metavariable is turned into a universe parameter. -/
+def abstractMVarsInst (e : Expr) : MetaM AbstractMVarsResult := do
+  let e ← instantiateMVars e
+  for m in (e.collectMVars {}).result do
+    m.setType (← instantiateMVars (← m.getType))
+  abstractMVars e
+
 /-- Add a typeclass instance to `candidateInsts`. -/
 partial def addAsCandidate (inst : Expr) : MonoM Unit := do
   if ← onlyHasGlobalFVars inst then
-    let ⟨levels, _, type⟩ ← abstractMVars (← inferType inst)
+    let ⟨levels, _, type⟩ ← abstractMVarsInst (← inferType inst)
     modify fun inst => { inst with candidateInsts := inst.candidateInsts.insert ⟨type, levels.toList⟩ }
 
 /-- Unfolds constants that are not global instances at the head of `e`.  -/
@@ -134,7 +143,8 @@ partial def unfoldInstDefn (e : Expr) : MetaM Expr := do
   return e
 
 /-- Apply `transform` to the type and local context of `goal`. -/
-def transformMVar [Monad n] [MonadLiftT MetaM n] [MonadMCtx n] (goal : MVarId) (transform : Expr → n Expr) : n (Expr × LocalContext) := do
+def transformMVar [Monad n] [MonadLiftT MetaM n] [MonadMCtx n] (goal : MVarId) (transform : Expr → n Expr)
+    (skipValue : FVarId → Bool := fun _ => false) : n (Expr × LocalContext) := do
   let decl := ((← getMCtx).findDecl? goal).get!
   let type ← transform decl.type
 
@@ -142,7 +152,9 @@ def transformMVar [Monad n] [MonadLiftT MetaM n] [MonadMCtx n] (goal : MVarId) (
     let decl := decl.setType (← transform decl.type)
 
     if let some value := decl.value? then
-      pure (decl.setValue (← transform value))
+      -- The value of a symbol is its own assignment; rewriting it would make it self-referential.
+      if skipValue decl.fvarId then pure decl
+      else pure (decl.setValue (← transform value))
     else pure decl
   }
 
@@ -153,11 +165,14 @@ def transformMVar [Monad n] [MonadLiftT MetaM n] [MonadMCtx n] (goal : MVarId) (
 partial def monoPattern (e : Expr) : MonoM (Option Expr) := do
   withApp e fun fn args => do
     let some (_, type, levels) ← getHeadInfo fn | return none
-    -- Assign new metavariable levels so outputs are independent of levels.
-    let mvarlevels ← mkFreshLevelMVars levels.length
-    let fn := fn.instantiateLevelParams levels mvarlevels
+    -- The pattern is built at the universe levels of `e`. A symbol is a local definition, so
+    -- it cannot be universe-polymorphic: each universe instantiation gets its own symbol,
+    -- and candidate instances (hence premise copies) keep the universes of the goal.
+    let us := match fn with
+      | .const _ us => us
+      | _ => []
     let (metas, binders, _) ← forallMetaTelescopeReducing
-      (type.instantiateLevelParams levels mvarlevels) args.size
+      (type.instantiateLevelParams levels us) args.size
     -- Check that `e` is eta expanded.
     if metas.size != args.size then return none
     for i in [0:binders.size] do
@@ -193,7 +208,7 @@ partial def monoTransformStep (e : Expr) : MonoM TransformStep := do
           if ← onlyHasGlobalFVars monoPattern then
             -- Abstract monoPattern before isDefEq, so as to not assign the mvars.
             let monoPattern ← instantiateMVars monoPattern
-            let ⟨paramNames, mvars, abstracted⟩ ← abstractMVars monoPattern
+            let ⟨paramNames, mvars, abstracted⟩ ← abstractMVarsInst monoPattern
             let specName := Name.mkSimple (((← toName fn).num cachedSpec.length).toStringWithSep "_" true)
             let specMvarId := (← mkFreshExprMVar (← inferType
               (abstracted.instantiateLevelParams paramNames.toList (← mkFreshLevelMVars paramNames.size))) .syntheticOpaque specName).mvarId!
@@ -294,7 +309,7 @@ def monomorphizeConst (name : Name) : MonoM (List Expr) := do
 
     let appliedExpr := mkAppN (Expr.const name levels) mvars
     let instantiated ← instantiateMVars appliedExpr
-    let abstrResult ← abstractMVars instantiated
+    let abstrResult ← abstractMVarsInst instantiated
     let binfos := abstrResult.mvars.map fun mvar =>
       (mvars.idxOf? mvar).map fun idx => binders[idx]!
 
@@ -315,8 +330,19 @@ def monomorphizeConst (name : Name) : MonoM (List Expr) := do
 
 structure MonoConfig where
   canonicalize : Bool := true
+  /-- Introduce the monomorphic symbols as `let`-bound local definitions rather than opaque
+  hypotheses. The transformed goal is then definitionally equal to the original one, which
+  is what makes proofs of it kernel-checkable. -/
+  defs : Bool := true
 
 declare_config_elab monoConfig MonoConfig
+
+/-- Add `name := val` to the context of `goal`, as a `let` if `defs` and as a hypothesis otherwise. -/
+def noteSymbol (goal : MVarId) (name : Name) (val : Expr) (defs : Bool) : MetaM (FVarId × MVarId) := do
+  if defs then
+    let g ← goal.define name (← inferType val) val
+    g.intro1P
+  else goal.note name val
 
 def monomorphizeTactic (goal : MVarId) (ids : Array Syntax) (config : MonoConfig) : MonoM MVarId := do
   -- Consider instImplicit local decls.
@@ -345,21 +371,25 @@ def monomorphizeTactic (goal : MVarId) (ids : Array Syntax) (config : MonoConfig
 
   -- Canonicalize by noting the `monos`.
   if config.canonicalize then
-    let goal ← (← get).mono.toList.foldlM (fun goal pair => do
-      let (_, monos) := pair
-      monos.foldlM (fun goal mono => do
+    let mut symFVars : HashSet FVarId := {}
+    let mut goal := goal
+    for (_, monos) in (← get).mono.toList do
+      for mono in monos do
         -- Assign the metavariable to a new local decl which is assigned to the monomorphization.
         let name := ((← getMCtx).getDecl mono.id).userName
-        let noteResult ← MVarId.note goal name (mono.assignment.expr.instantiateLevelParams mono.assignment.levels (mono.assignment.levels.map (fun _ => Level.zero)))
+        let noteResult ← noteSymbol goal name (mono.assignment.expr.instantiateLevelParams mono.assignment.levels (mono.assignment.levels.map (fun _ => Level.zero))) config.defs
         mono.id.assign (.fvar noteResult.1)
-        pure noteResult.2
-      ) goal
-    ) goal
+        symFVars := symFVars.insert noteResult.1
+        goal := noteResult.2
 
-    -- The second pass substitutes the `monos`.
-    let (type, lctx) ← transformMVar goal fun e => Meta.transform e (pre := monoTransformStep)
+    -- The second pass substitutes the `monos`. It runs in the context of `goal`, which is
+    -- where the symbols and copies exist.
+    let (type, lctx) ← goal.withContext <| transformMVar goal
+      (fun e => Meta.transform e (pre := monoTransformStep)) (skipValue := symFVars.contains)
     -- Failsafe for new `monos` being added during the second pass.
     let _ ← finalizeMonos
     let _ ← goal.modifyLCtx fun _ => lctx
+    -- The types of existing free variables changed: cached inferred types are stale.
+    resetCache
     goal.replaceTargetDefEq type
   else return goal


### PR DESCRIPTION
`monomorphize` introduces its symbols with `MVarId.note`, i.e. as opaque hypotheses, so the transformed goal is not definitionally equal to the original in its own context and nothing built on it can pass the kernel. Previously, we had the following error

```lean
theorem t1 (a b : Nat) : a + b = b + a := by
  monomorphize [Nat.add_comm]
  exact Nat_add_comm_0 a b
-- error: Type mismatch
--   Nat_add_comm_0 a b has type a + b = b + a
--   but is expected to have type HAdd_hAdd_0 a b = HAdd_hAdd_0 b a
```

This PR makes the symbols `let`-bound local definitions (`MonoConfig.defs`, on by default). Opaque symbols (symbol introduced as hypothesis) look like it can't be sound because the specialized premises are proved by Mathlib constants at their raw types (`a + b = b + a`) but presented at the rewritten types (`HAdd_hAdd_0 a b = HAdd_hAdd_0 b a`), and the two agree only if the symbol unfolds. 

There's also minor things that I discovered:

- `monoPattern` renamed the head constant's universe parameters by name, which also renamed the goal's own `u` when it happened to match (`HPow.hPow.{u, v, w}` in a goal about `Cardinal.{u}` gave a symbol at `u + 2`). Patterns are now built at the occurrence's actual levels; a `let` cannot be universe-polymorphic anyway, so each universe instantiation gets its own symbol.
-  `abstractMvars` read uninstantiated metavariable types and re-abstracted an already solved universe, which was then set to `0`. `abstractMvarsInst` instantiates the types first.
- Second canonicalization pass ran in the old goal's context, where the symbols do not exist and rewrote the symbols' own `let` values into self-references It should now run in the new goal's context and skips symbol values. Also made it reset cache as I learned that it sometimes reports old types.

The above example pass with this branch. This also helps the original goal proof go through for the monomorphized version in multiple cases (like universe-polymorphic goal (`(α : Type u) (l : List α) : l ++ [] = l` with `List.append_nil`) ).
